### PR TITLE
Add ty type checking and improve make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ EXAMPLES_OUTPUTS=${subst $(EXAMPLE_INPUT_DIR), $(EXAMPLE_OUTPUT_DIR), $(EXAMPLES
     check-all \
     check-lint \
     check-lock \
+    check-types \
     clean \
     fix-all \
     fix-format \
@@ -42,51 +43,72 @@ EXAMPLES_OUTPUTS=${subst $(EXAMPLE_INPUT_DIR), $(EXAMPLE_OUTPUT_DIR), $(EXAMPLES
     run-tests \
     sync
 
+## Run all checks and tests
 default: check-all run-tests
 
+## Sync dependencies and build all disk images
 all: sync $(TARGET) $(TARGET_DECB)
 
+## Build source distribution
 build-dist: sync
 	uv build --verbose --sdist
 
-check-all: check-lock check-lint
+## Run all checks (lock, lint, types)
+check-all: check-lock check-lint check-types
 
+## Run ruff linter
 check-lint: check-lock
 	uv run ruff check
 
+## Verify uv.lock is up to date
 check-lock:
 	uv lock --locked
 
+## Run ty type checker
+check-types: check-lock
+	uv tool run ty check
+
+## Remove build artifacts and caches
 clean:
 	rm -rf .ruff_cache .venv build .cache *.egg-info dist $(TARGET) $(TMPTARGET) $(TARGET_DECB) $(TMPTARGET_DECB) $(EXAMPLES_OUTPUTS)
 
+## Auto-fix formatting and lint issues, then update lock
 fix-all: fix-format fix-lint lock
 
+## Auto-format code with ruff
 fix-format: check-lock
 	uv run ruff format
 
+## Auto-fix lint issues with ruff
 fix-lint: check-lock
 	uv run ruff check --fix
 
+## Auto-fix lint issues including unsafe fixes
 fix-lint-unsafe: check-lock
 	uv run ruff check --fix --unsafe-fixes
 
+## Show this help
 help:
-	@echo ${.PHONY}
+	@grep -B1 -E '^[a-zA-Z_-]+:' $(MAKEFILE_LIST) | grep -E '^##|^[a-zA-Z_-]+:' | sed 'N;s/\n/ /' | sed 's/## \(.*\) \([a-zA-Z_-]*\):.*/\2\t\1/' | sort | awk -F'\t' '{ printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 }'
 
+## Install package
 install: check-lock build-dist
 	uv pip install .
 
+## Install pre-commit hooks
 install-pre-commit:
 	uv run pre-commit install
 
+## Update uv.lock
 lock:
 	uv lock
 
+## Run tests with coverage
 run-tests: check-lock
 	uv run coverage run -m pytest
 	uv run coverage report --show-missing
 
+## Sync dependencies
 sync: check-lock
 	uv sync --no-install-workspace
 

--- a/coco/b09/compiler.py
+++ b/coco/b09/compiler.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import List
+from typing import IO, List
 
 from coco import b09
 from coco.b09 import error_handler
@@ -50,7 +52,7 @@ def convert(
     *,
     add_standard_prefix: bool = True,
     add_suffix: bool = True,
-    compiler_configs: CompilerConfigs = None,
+    compiler_configs: CompilerConfigs | None = None,
     default_str_storage: int = b09.DEFAULT_STR_STORAGE,
     default_width32: bool = True,
     filter_unused_linenum: bool = False,
@@ -187,8 +189,13 @@ def convert(
     basic_prog.visit(on_err_collector)
     if len(on_err_collector.statements) > 1:
         raise ParseError("At most 1 ON ERR GOTO statement is allowed.")
-    err_line: BasicOnErrGoStatement = (
-        on_err_collector.statements[0].linenum if on_err_collector.statements else None
+    err_statement = (
+        on_err_collector.statements[0] if on_err_collector.statements else None
+    )
+    err_line: int | None = (
+        err_statement.linenum
+        if isinstance(err_statement, BasicOnErrGoStatement)
+        else None
     )
 
     # make sure there are no more than 1 ON BRK statement
@@ -198,8 +205,13 @@ def convert(
     basic_prog.visit(on_brk_collector)
     if len(on_brk_collector.statements) > 1:
         raise ParseError("At most 1 ON BRK GOTO statement is allowed.")
-    brk_line: BasicOnBrkGoStatement = (
-        on_brk_collector.statements[0].linenum if on_brk_collector.statements else None
+    brk_statement = (
+        on_brk_collector.statements[0] if on_brk_collector.statements else None
+    )
+    brk_line: int | None = (
+        brk_statement.linenum
+        if isinstance(brk_statement, BasicOnBrkGoStatement)
+        else None
     )
 
     # try to patch up empty next statements
@@ -243,11 +255,11 @@ def convert(
 
 
 def convert_file(
-    input_program_file: str,
-    output_program_file: str,
+    input_program_file: IO[str],
+    output_program_file: IO[str],
     *,
     add_standard_prefix: bool = True,
-    config_file: str = None,
+    config_file: str | None = None,
     default_width32: bool = True,
     default_str_storage: int = b09.DEFAULT_STR_STORAGE,
     filter_unused_linenum: bool = False,

--- a/coco/b09/elements.py
+++ b/coco/b09/elements.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Iterable
 from itertools import chain
 from typing import TYPE_CHECKING, Dict, List, Literal, Union
 
 from coco.b09 import DEFAULT_STR_STORAGE
 
 if TYPE_CHECKING:
-    from visitors import BasicConstructVisitor
+    from coco.b09.visitors import BasicConstructVisitor
 
 
 class AbstractBasicConstruct(ABC):
@@ -77,8 +80,8 @@ class AbstractBasicStatement(AbstractBasicConstruct):
             + (r" \ " if self._pre_assignment_statements else "")
         )
 
-    def visit(self, vistor: "BasicConstructVisitor") -> None:
-        return vistor.visit_statement(self)
+    def visit(self, visitor: "BasicConstructVisitor") -> None:
+        visitor.visit_statement(self)
 
 
 class BasicArrayRef(AbstractBasicExpression):
@@ -109,15 +112,18 @@ class BasicArrayRef(AbstractBasicExpression):
 
 class BasicAssignment(AbstractBasicStatement):
     def __init__(
-        self, var: "BasicVar", exp: AbstractBasicExpression, let_kw: bool = False
+        self,
+        var: AbstractBasicExpression,
+        exp: AbstractBasicExpression,
+        let_kw: bool = False,
     ):
         super().__init__()
         self._let_kw: bool = let_kw
         self._var: AbstractBasicExpression = var
-        self._exp: BasicVar = exp
+        self._exp: AbstractBasicExpression = exp
 
     @property
-    def var(self) -> "BasicVar":
+    def var(self) -> AbstractBasicExpression:
         return self._var
 
     @property
@@ -200,13 +206,13 @@ class BasicBinaryExp(AbstractBasicExpression):
     def __init__(
         self,
         exp1: AbstractBasicExpression,
-        op: "BasicOperator",
+        op: str | BasicOperator,
         exp2: AbstractBasicExpression,
         is_str_expr: bool = False,
     ):
         super().__init__(is_str_expr=True)
         self._exp1: AbstractBasicExpression = exp1
-        self._op: BasicOperator = op
+        self._op: str | BasicOperator = op
         self._exp2: AbstractBasicExpression = exp2
 
     def basic09_text(self, indent_level: int) -> str:
@@ -380,7 +386,7 @@ class BasicIf(AbstractBasicStatement):
     ):
         super().__init__()
         self._exp: AbstractBasicExpression = exp
-        self._statements: BasicStatements = statements
+        self._statements: BasicStatementsOrBasicGoto = statements
 
     def basic09_text(self, indent_level: int) -> str:
         if isinstance(self._statements, BasicGoto) and self._statements.implicit:
@@ -407,13 +413,13 @@ class BasicIf(AbstractBasicStatement):
         return self._exp
 
     @property
-    def statements(self) -> AbstractBasicExpression:
+    def statements(self) -> BasicStatementsOrBasicGoto:
         return self._statements
 
 
 class BasicIfElse(BasicIf):
     _else_if_statements: List[BasicIf]
-    _else_statements: BasicStatementsOrBasicGoto
+    _else_statements: BasicStatementsOrBasicGoto | None
 
     def __init__(
         self,
@@ -475,9 +481,9 @@ class BasicIfElse(BasicIf):
 
 
 class BasicLine(AbstractBasicConstruct):
-    def __init__(self, num: Union[int, None], statements: "BasicStatement"):
-        self._num: Union[int, None] = num
-        self._statements: BasicStatement = statements
+    def __init__(self, num: int | None, statements: AbstractBasicStatement):
+        self._num: int | None = num
+        self._statements: AbstractBasicStatement = statements
         self._is_referenced: bool = True
 
     @property
@@ -565,8 +571,9 @@ class BasicOperator(AbstractBasicConstruct):
         return self._operator
 
 
-class BasicOpExp(AbstractBasicConstruct):
+class BasicOpExp(AbstractBasicExpression):
     def __init__(self, operator, exp):
+        super().__init__()
         self._operator = operator
         self._exp = exp
 
@@ -642,16 +649,18 @@ class Basic09CodeStatement(AbstractBasicStatement):
 
 
 class BasicStatements(AbstractBasicStatement):
-    def __init__(self, statements: List[BasicStatement], multi_line: bool = True):
+    def __init__(
+        self, statements: Iterable[AbstractBasicStatement], multi_line: bool = True
+    ):
         super().__init__()
-        self._statements = list(statements)
+        self._statements: list[AbstractBasicStatement] = list(statements)
         self._multi_line: bool = multi_line
 
     @property
-    def statements(self) -> List[BasicStatement]:
+    def statements(self) -> list[AbstractBasicStatement]:
         return self._statements
 
-    def set_statements(self, statements: List[BasicStatement]) -> None:
+    def set_statements(self, statements: list[AbstractBasicStatement]) -> None:
         self._statements = statements
 
     def basic09_text(self, indent_level: int, pre_indent: bool = True) -> str:
@@ -787,12 +796,15 @@ class BasicSound(Basic2ParamStatement):
 
 class BasicPoke(Basic2ParamStatement):
     def basic09_text(self, indent_level: int) -> str:
-        known_loc: bool = isinstance(self._exp1, BasicLiteral) or isinstance(
-            self._exp1, HexLiteral
-        )
-        if known_loc and self._exp1.literal == 65496:
+        if (
+            isinstance(self._exp1, (BasicLiteral, HexLiteral))
+            and self._exp1.literal == 65496
+        ):
             return f"{super().basic09_text(indent_level)}play.octo := 0"
-        elif known_loc and self._exp1.literal == 65497:
+        elif (
+            isinstance(self._exp1, (BasicLiteral, HexLiteral))
+            and self._exp1.literal == 65497
+        ):
             return f"{super().basic09_text(indent_level)}play.octo := 1"
         else:
             return (
@@ -947,7 +959,7 @@ class BasicFunctionalExpression(AbstractBasicExpression):
         return self._var.basic09_text(indent_level) if self._var else ""
 
     def visit(self, visitor: "BasicConstructVisitor") -> None:
-        if self._var:
+        if self._var and self._statement:
             self._statement.visit(visitor)
             self._var.visit(visitor)
         else:
@@ -1229,7 +1241,7 @@ class BasicCircleStatement(BasicRunCall):
     _expr_x: AbstractBasicExpression
     _expr_y: AbstractBasicExpression
     _expr_r: AbstractBasicExpression
-    _expr_color: AbstractBasicExpression
+    _expr_color: AbstractBasicExpression | None
     _hires: bool
 
     def __init__(
@@ -1238,7 +1250,7 @@ class BasicCircleStatement(BasicRunCall):
         expr_y: AbstractBasicExpression,
         expr_r: AbstractBasicExpression,
         *,
-        expr_color: AbstractBasicConstruct = None,
+        expr_color: AbstractBasicExpression | None = None,
         hires: bool = True,
     ):
         super().__init__(
@@ -1281,7 +1293,7 @@ class BasicCircleStatement(BasicRunCall):
         return self._expr_r
 
     @property
-    def expr_color(self) -> AbstractBasicExpression:
+    def expr_color(self) -> AbstractBasicExpression | None:
         return self._expr_color
 
 
@@ -1412,7 +1424,7 @@ class HLineStatement(BasicRunCall):
     def __init__(
         self,
         *,
-        source: Coordinates,
+        source: Coordinates | None,
         destination: Coordinates,
         mode: PsetOrPreset,
         line_type: LineType,

--- a/coco/b09/parser.py
+++ b/coco/b09/parser.py
@@ -494,9 +494,7 @@ class BasicVisitor(NodeVisitor):
     ) -> List[BasicBinaryExpFragment]:
         return visited_children
 
-    def visit_num_power_sub_exp(
-        self, node, visited_children
-    ) -> AbstractBasicExpression:
+    def visit_num_power_sub_exp(self, node, visited_children) -> BasicBinaryExpFragment:
         op, _, exp, _ = visited_children
         return BasicBinaryExpFragment(op, exp)
 
@@ -865,7 +863,7 @@ class BasicVisitor(NodeVisitor):
         _, _, dim_var_list = visited_children
         return BasicDimStatement(dim_var_list)
 
-    def visit_clear_statement(self, node, visited_children) -> AbstractBasicStatement:
+    def visit_clear_statement(self, node, visited_children) -> AbstractBasicConstruct:
         return BasicComment(f" {node.text.strip()}")
 
     def visit_read_statement(self, _, visited_children) -> AbstractBasicStatement:

--- a/coco/b09/visitors.py
+++ b/coco/b09/visitors.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List, Set
 
 from coco import b09
 from coco.b09.configs import StringConfigs
 from coco.b09.elements import (
+    AbstractBasicConstruct,
     AbstractBasicExpression,
     AbstractBasicStatement,
     Basic09CodeStatement,
@@ -25,7 +28,6 @@ from coco.b09.elements import (
     BasicPrintStatement,
     BasicReadStatement,
     BasicRunCall,
-    BasicStatement,
     BasicStatements,
     BasicVar,
 )
@@ -41,7 +43,7 @@ class BasicConstructVisitor:
         """
         pass
 
-    def visit_data_statement(self, for_statement: BasicDataStatement) -> None:
+    def visit_data_statement(self, statement: BasicDataStatement) -> None:
         """
         Invoked when a DATA statement is encountered.
         """
@@ -95,7 +97,9 @@ class BasicConstructVisitor:
         """
         pass
 
-    def visit_print_statement(self, statement: BasicPrintStatement) -> None:
+    def visit_print_statement(
+        self, statement: BasicPrintStatement
+    ) -> AbstractBasicStatement:
         """
         Args:
             statement (BasicPrintStatement): input statement to transform.
@@ -123,7 +127,7 @@ class BasicConstructVisitor:
         """
         return statement
 
-    def visit_statement(self, statement: BasicStatement) -> None:
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         """
         Invoked when a statement is encountered.
         """
@@ -144,10 +148,10 @@ class ForNextVisitor(BasicConstructVisitor):
     def count(self):
         return self._count
 
-    def visit_for_statement(self, _: BasicForStatement):
+    def visit_for_statement(self, for_statement: BasicForStatement) -> None:
         self._count = self._count + 1
 
-    def visit_next_statement(self, next_statement: BasicNextStatement):
+    def visit_next_statement(self, next_statement: BasicNextStatement) -> None:
         self._count = self._count - len(next_statement.var_list.exp_list)
 
 
@@ -204,17 +208,17 @@ class LineZeroFilterVisitor(BasicConstructVisitor):
 
 class StatementCollectorVisitor(BasicConstructVisitor):
     _statement_type: type
-    _statements: List[BasicStatement]
+    _statements: List[AbstractBasicConstruct]
 
     @property
-    def statements(self) -> List[BasicStatement]:
+    def statements(self) -> List[AbstractBasicConstruct]:
         return self._statements
 
     def __init__(self, statement_type: type):
         self._statements = []
         self._statement_type = statement_type
 
-    def visit_statement(self, statement: BasicStatement):
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         if type(statement) is self._statement_type:
             self._statements.append(statement)
         super().visit_statement(statement)
@@ -257,7 +261,7 @@ class VarInitializerVisitor(BasicConstructVisitor):
     def visit_var(self, var) -> None:
         self._vars.add(var.name())
 
-    def visit_statement(self, statement: BasicForStatement) -> None:
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         if isinstance(statement, BasicDimStatement):
             self._dimmed_var_names.update(
                 [
@@ -318,7 +322,7 @@ class SetDimStringStorageVisitor(BasicConstructVisitor):
             for var, size in string_configs.strname_to_size.items()
         }
 
-    def visit_statement(self, statement: BasicStatement) -> None:
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         if isinstance(statement, BasicDimStatement):
             statement.default_str_storage = self._default_str_storage
             statement.strname_to_size = self._strname_to_size
@@ -340,7 +344,7 @@ class GetDimmedArraysVisitor(BasicConstructVisitor):
     def __init__(self):
         self._dimmed_var_names = set()
 
-    def visit_statement(self, statement: BasicStatement) -> None:
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         if isinstance(statement, BasicDimStatement):
             self._dimmed_var_names.update(
                 [
@@ -373,7 +377,7 @@ class DeclareImplicitArraysVisitor(BasicConstructVisitor):
         return self._referenced_var_names - self._dimmed_var_names
 
     @property
-    def dim_statements(self) -> List[BasicStatement]:
+    def dim_statements(self) -> List[BasicDimStatement]:
         return [
             BasicDimStatement(
                 [
@@ -415,7 +419,7 @@ class BasicEmptyDataElementVisitor(BasicConstructVisitor):
     def has_empty_data_elements(self):
         return self._has_empty_data_elements
 
-    def visit_data_statement(self, statement: BasicDataStatement):
+    def visit_data_statement(self, statement: BasicDataStatement) -> None:
         for exp in statement.exp_list.exp_list:
             self._has_empty_data_elements = (
                 self._has_empty_data_elements or exp.literal == ""
@@ -423,13 +427,15 @@ class BasicEmptyDataElementVisitor(BasicConstructVisitor):
 
 
 class BasicReadStatementPatcherVisitor(BasicConstructVisitor):
-    def visit_data_statement(self, statement: BasicDataStatement):
+    def visit_data_statement(self, statement: BasicDataStatement) -> None:
         exp: AbstractBasicExpression
         for exp in statement.exp_list.exp_list:
             if not isinstance(exp.literal, str):
                 exp.literal = str(exp.literal)
 
-    def visit_read_statement(self, statement: BasicReadStatement):
+    def visit_read_statement(
+        self, statement: BasicReadStatement
+    ) -> AbstractBasicStatement:
         """
         Transform the READ statement so that READ statements that read into
         REAL vars properly handle empty strings. This means:
@@ -459,7 +465,9 @@ class BasicReadStatementPatcherVisitor(BasicConstructVisitor):
 
 
 class BasicInputStatementPatcherVisitor(BasicConstructVisitor):
-    def visit_input_statement(self, statement: BasicInputStatement):
+    def visit_input_statement(
+        self, statement: BasicInputStatement
+    ) -> AbstractBasicStatement:
         """
         Transform the INPUT statement so that the cursor and full duplex are
         enabled before the statement and disabled after the statement.
@@ -476,7 +484,9 @@ class BasicInputStatementPatcherVisitor(BasicConstructVisitor):
 
 
 class BasicPrintStatementPatcherVisitor(BasicConstructVisitor):
-    def visit_print_statement(self, statement: BasicPrintStatement):
+    def visit_print_statement(
+        self, statement: BasicPrintStatement
+    ) -> AbstractBasicStatement:
         """
         Transform the PRINT statement so that non string expressions are
         converted to strings via STR.
@@ -511,17 +521,18 @@ class BasicFunctionalExpressionPatcherVisitor(BasicConstructVisitor):
     def __init__(self):
         self._statement = None
 
-    def visit_statement(self, statement: BasicStatement):
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         self._statement = statement
         if isinstance(statement, BasicAssignment) and isinstance(
             statement.exp, BasicFunctionalExpression
         ):
             statement.exp.set_var(statement.var)
 
-    def visit_exp(self, exp):
+    def visit_exp(self, exp) -> None:
         if not isinstance(exp, BasicFunctionalExpression) or exp.var:
             return
-        self._statement.transform_function_to_call(exp)
+        if isinstance(self._statement, AbstractBasicStatement):
+            self._statement.transform_function_to_call(exp)
 
 
 class BasicHbuffPresenceVisitor(BasicConstructVisitor):
@@ -530,7 +541,7 @@ class BasicHbuffPresenceVisitor(BasicConstructVisitor):
     def __init__(self):
         self._hasHbuff = False
 
-    def visit_statement(self, statement: BasicStatement) -> None:
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         if isinstance(statement, BasicHbuffStatement):
             self._hasHbuff = True
 
@@ -543,6 +554,6 @@ class SetInitializeVisitor(BasicConstructVisitor):
     def __init__(self, initialize_vars: bool):
         self._initialize_vars = initialize_vars
 
-    def visit_statement(self, statement: BasicStatement) -> None:
+    def visit_statement(self, statement: AbstractBasicConstruct) -> None:
         if isinstance(statement, BasicDimStatement):
             statement.initialize_vars = self._initialize_vars

--- a/coco/png_utilities.py
+++ b/coco/png_utilities.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from io import BufferedWriter
-from typing import Optional
+from pathlib import Path
+from typing import Any, Optional, cast
 
 import numpy as np
 from colormath.color_conversions import convert_color
@@ -50,7 +53,7 @@ class LCHEntry:
         return cls(luminence=lch.lch_l, chroma=lch.lch_c, hue=lch.lch_h)
 
 
-def _parse_input_palette(palette_path: str) -> Mapping[int, PaletteEntry]:
+def _parse_input_palette(palette_path: str | Path) -> Mapping[int, PaletteEntry]:
     with open(palette_path, "r") as file:
         env_file_contents = file.readlines()
     for line in env_file_contents:
@@ -126,10 +129,10 @@ def _truncate_palette_to_bits_per_pixel(
 
 
 def _load_png_image_as_2darray(
-    image_path: str,
+    image_path: str | Path,
 ) -> list[list[tuple[int, int, int, int]]]:
     image = Image.open(image_path).convert("RGBA")
-    pixel_data = list(image.getdata())
+    pixel_data: list[tuple[int, int, int, int]] = list(cast(Any, image.getdata()))
     width, height = image.size
     pixel_2d_array = [pixel_data[i * width : (i + 1) * width] for i in range(height)]
     return pixel_2d_array
@@ -253,8 +256,8 @@ def _create_mvicon_arg_parser() -> argparse.ArgumentParser:
 
 def _reduce_image_colors(
     *,
-    input_png_path: str,
-    input_palette_path: str,
+    input_png_path: str | Path,
+    input_palette_path: str | Path,
     bits_per_pixel: int,
 ) -> IndexedImage:
     rgb_palette = _parse_input_palette(input_palette_path)
@@ -274,8 +277,8 @@ def _reduce_image_colors(
 
 def convert_png_to_mvicon(
     *,
-    input_png_path: str,
-    input_palette_path: str,
+    input_png_path: str | Path,
+    input_palette_path: str | Path,
     output_icon_path: str,
     bits_per_pixel: int,
 ) -> None:
@@ -302,7 +305,7 @@ def png_to_mvicon(args: Optional[Sequence[str]] = None) -> None:
     )
 
 
-def indexed_image_to_image(indexed_image: IndexedImage) -> Image:
+def indexed_image_to_image(indexed_image: IndexedImage) -> Image.Image:
     def two_to_8_bit(b: int):
         return b * 85
 
@@ -323,8 +326,8 @@ def indexed_image_to_image(indexed_image: IndexedImage) -> Image:
 
 def convert_png_to_coco_png(
     *,
-    input_png_path: str,
-    input_palette_path: str,
+    input_png_path: str | Path,
+    input_palette_path: str | Path,
     output_png_path: str,
     bits_per_pixel: int,
 ) -> None:
@@ -363,7 +366,7 @@ def _mask_for_indexed_image(
 
 def _write_os9_image_file(
     *,
-    output_os9_image_path: str,
+    output_os9_image_path: str | Path,
     png_palette_indices_2d_array: list[list[int]],
     bits_per_pixel: int,  # 1, 2 or 4
 ) -> None:
@@ -393,9 +396,9 @@ def _write_os9_image_file(
 
 def convert_png_to_os9_image(
     *,
-    input_png_path: str,
-    input_palette_path: str,
-    output_os9_image_path: str,
+    input_png_path: str | Path,
+    input_palette_path: str | Path,
+    output_os9_image_path: str | Path,
     bits_per_pixel: int,
     create_mask: bool,
     mask_index: int = -1,

--- a/tests/coco_tests/b09/test_b09.py
+++ b/tests/coco_tests/b09/test_b09.py
@@ -1,7 +1,6 @@
 import unittest
 
-from coco import b09
-from coco.b09 import compiler
+from coco.b09 import DEFAULT_STR_STORAGE, compiler, elements, grammar
 from coco.b09.compiler import ParseError
 from coco.b09.configs import CompilerConfigs, StringConfigs
 from coco.b09.visitors import LineNumberTooLargeException
@@ -74,84 +73,84 @@ class TestB09(unittest.TestCase):
         assert "RUN _ecb_start(display, 1)\n" in program
 
     def test_basic_assignment(self) -> None:
-        var = b09.elements.BasicVar("HW")
-        exp = b09.elements.BasicLiteral(123.0)
-        target = b09.elements.BasicAssignment(var, exp)
+        var = elements.BasicVar("HW")
+        exp = elements.BasicLiteral(123.0)
+        target = elements.BasicAssignment(var, exp)
         assert target.basic09_text(1) == "  HW := 123.0"
 
     def test_basic_binary_exp(self) -> None:
-        var = b09.elements.BasicVar("HW")
-        strlit = b09.elements.BasicLiteral("HW")
-        target = b09.elements.BasicBinaryExp(var, "=", strlit)
+        var = elements.BasicVar("HW")
+        strlit = elements.BasicLiteral("HW")
+        target = elements.BasicBinaryExp(var, "=", strlit)
         assert target.basic09_text(1) == 'HW = "HW"'
 
     def test_comment(self) -> None:
-        target = b09.elements.BasicComment(" hello world ")
+        target = elements.BasicComment(" hello world ")
         assert target.basic09_text(1) == "(* hello world  *)"
 
     def test_comment_statement(self) -> None:
-        comment = b09.elements.BasicComment(" hello world ")
-        target = b09.elements.BasicStatement(comment)
+        comment = elements.BasicComment(" hello world ")
+        target = elements.BasicStatement(comment)
         assert target.basic09_text(2) == "    (* hello world  *)"
 
     def test_comment_statements(self) -> None:
-        comment = b09.elements.BasicComment(" hello world ")
-        statement = b09.elements.BasicStatement(comment)
-        target = b09.elements.BasicStatements((statement,))
+        comment = elements.BasicComment(" hello world ")
+        statement = elements.BasicStatement(comment)
+        target = elements.BasicStatements((statement,))
         assert target.basic09_text(2) == "    (* hello world  *)"
 
     def test_comment_lines(self) -> None:
-        comment = b09.elements.BasicComment(" hello world ")
-        statement = b09.elements.BasicStatement(comment)
-        statements = b09.elements.BasicStatements((statement,))
-        target = b09.elements.BasicLine(25, statements)
+        comment = elements.BasicComment(" hello world ")
+        statement = elements.BasicStatement(comment)
+        statements = elements.BasicStatements((statement,))
+        target = elements.BasicLine(25, statements)
         assert target.basic09_text(1) == "25   (* hello world  *)"
 
     def test_basic_float_literal(self) -> None:
-        target = b09.elements.BasicLiteral(123.0)
+        target = elements.BasicLiteral(123.0)
         assert target.basic09_text(2) == "123.0"
 
     def test_basic_goto(self) -> None:
-        target = b09.elements.BasicGoto(123, True)
+        target = elements.BasicGoto(123, True)
         assert target.basic09_text(1) == "123"
         assert target.implicit is True
-        target = b09.elements.BasicGoto(1234, False)
+        target = elements.BasicGoto(1234, False)
         assert target.basic09_text(1) == "  GOTO 1234"
         assert target.implicit is False
 
     def test_if(self) -> None:
-        strlit = b09.elements.BasicLiteral("HW")
-        exp = b09.elements.BasicBinaryExp(strlit, "=", strlit)
-        goto = b09.elements.BasicGoto(123, True)
-        target = b09.elements.BasicIf(exp, goto)
+        strlit = elements.BasicLiteral("HW")
+        exp = elements.BasicBinaryExp(strlit, "=", strlit)
+        goto = elements.BasicGoto(123, True)
+        target = elements.BasicIf(exp, goto)
         assert target.basic09_text(1) == '  IF "HW" = "HW" THEN 123'
 
     def test_basic_real_literal(self) -> None:
-        target = b09.elements.BasicLiteral(123.0)
+        target = elements.BasicLiteral(123.0)
         assert target.basic09_text(2) == "123.0"
 
     def test_basic_int_literal(self) -> None:
-        target = b09.elements.BasicLiteral(123)
+        target = elements.BasicLiteral(123)
         assert target.basic09_text(2) == "123"
 
     def test_basic_str_literal(self) -> None:
-        target = b09.elements.BasicLiteral("123.0")
+        target = elements.BasicLiteral("123.0")
         assert target.basic09_text(1) == '"123.0"'
 
     def test_basic_paren_exp(self) -> None:
-        strlit = b09.elements.BasicLiteral("HELLO WORLD")
-        target = b09.elements.BasicParenExp(strlit)
+        strlit = elements.BasicLiteral("HELLO WORLD")
+        target = elements.BasicParenExp(strlit)
         assert target.basic09_text(2) == '("HELLO WORLD")'
 
     def test_basic_op_exp(self) -> None:
-        strlit = b09.elements.BasicLiteral("HELLO WORLD")
-        target = b09.elements.BasicOpExp("&", strlit)
+        strlit = elements.BasicLiteral("HELLO WORLD")
+        target = elements.BasicOpExp("&", strlit)
         assert target.operator == "&"
         assert target.exp == strlit
         assert target.basic09_text(1) == '& "HELLO WORLD"'
 
     def test_basic_operator(self) -> None:
-        target = b09.elements.BasicOperator("*")
+        target = elements.BasicOperator("*")
         assert target.basic09_text(2) == "*"
 
     def generic_test_parse(
@@ -161,7 +160,7 @@ class TestB09(unittest.TestCase):
         *,
         add_standard_prefix=False,
         add_suffix=False,
-        default_str_storage=b09.DEFAULT_STR_STORAGE,
+        default_str_storage=DEFAULT_STR_STORAGE,
         filter_unused_linenum=False,
         initialize_vars=False,
         output_dependencies=False,
@@ -395,7 +394,7 @@ class TestB09(unittest.TestCase):
         )
 
     def test_funcs(self) -> None:
-        for ecb_func, b09_func in b09.grammar.FUNCTIONS.items():
+        for ecb_func, b09_func in grammar.FUNCTIONS.items():
             self.generic_test_parse(
                 f"11X={ecb_func}(1)",
                 f"11 X := {b09_func}(1.0)",
@@ -429,20 +428,20 @@ class TestB09(unittest.TestCase):
         self.generic_test_parse('11 AA = VAL("2334")', '11 RUN ecb_val("2334", AA)')
 
     def test_num_str_funcs(self) -> None:
-        for ecb_func, b09_func in b09.grammar.NUM_STR_FUNCTIONS.items():
+        for ecb_func, b09_func in grammar.NUM_STR_FUNCTIONS.items():
             self.generic_test_parse(
                 f"11X$={ecb_func}(1)",
                 f"11 X$ := {b09_func}(1.0)",
             )
 
     def test_builtin_statements(self) -> None:
-        for ecb_func, b09_func in b09.grammar.STATEMENTS2.items():
+        for ecb_func, b09_func in grammar.STATEMENTS2.items():
             self.generic_test_parse(
                 f"11{ecb_func}(1,2)",
                 f"11 {b09_func}(1.0, 2.0)",
             )
 
-        for ecb_func, b09_func in b09.grammar.STATEMENTS3.items():
+        for ecb_func, b09_func in grammar.STATEMENTS3.items():
             self.generic_test_parse(
                 f"11{ecb_func}(1,2    , 3)",
                 f"11 {b09_func}(1.0, 2.0, 3.0)",
@@ -471,7 +470,7 @@ class TestB09(unittest.TestCase):
         for (
             ecb_func,
             b09_func,
-        ) in b09.grammar.SINGLE_KEYWORD_STATEMENTS.items():
+        ) in grammar.SINGLE_KEYWORD_STATEMENTS.items():
             self.generic_test_parse(
                 f"11{ecb_func}",
                 f"11 {b09_func}",
@@ -527,14 +526,14 @@ class TestB09(unittest.TestCase):
         )
 
     def test_functions_to_statements(self) -> None:
-        for ecb_func, b09_func in b09.grammar.FUNCTIONS_TO_STATEMENTS.items():
+        for ecb_func, b09_func in grammar.FUNCTIONS_TO_STATEMENTS.items():
             self.generic_test_parse(
                 f"11X={ecb_func}(1)",
                 f"11 {b09_func}(1.0, X)",
             )
 
     def test_functions_to_statements2(self) -> None:
-        for ecb_func, b09_func in b09.grammar.FUNCTIONS_TO_STATEMENTS2.items():
+        for ecb_func, b09_func in grammar.FUNCTIONS_TO_STATEMENTS2.items():
             self.generic_test_parse(
                 f"11X={ecb_func}(1, 2)",
                 f"11 {b09_func}(1.0, 2.0, X)",
@@ -544,7 +543,7 @@ class TestB09(unittest.TestCase):
         for (
             ecb_func,
             b09_func,
-        ) in b09.grammar.NUM_STR_FUNCTIONS_TO_STATEMENTS.items():
+        ) in grammar.NUM_STR_FUNCTIONS_TO_STATEMENTS.items():
             self.generic_test_parse(
                 f"11X$={ecb_func}(1)",
                 f"11 {b09_func}(1.0, X$)",
@@ -554,7 +553,7 @@ class TestB09(unittest.TestCase):
         for (
             ecb_func,
             b09_func,
-        ) in b09.grammar.STR_FUNCTIONS_TO_STATEMENTS.items():
+        ) in grammar.STR_FUNCTIONS_TO_STATEMENTS.items():
             self.generic_test_parse(
                 f"11X$={ecb_func}",
                 f"11 {b09_func}(X$)",

--- a/tests/coco_tests/b09/test_visitors.py
+++ b/tests/coco_tests/b09/test_visitors.py
@@ -21,7 +21,7 @@ from coco.b09.visitors import (
 
 def parse_program(resource_name: str) -> BasicProg:
     with importlib_resources.as_file(
-        importlib_resources.files(__package__) / f"fixtures/{resource_name}"
+        importlib_resources.files(str(__package__)) / f"fixtures/{resource_name}"
     ) as path:
         prog: str
         with open(path) as f:

--- a/tests/coco_tests/test_cm3toppm.py
+++ b/tests/coco_tests/test_cm3toppm.py
@@ -35,10 +35,10 @@ class TestCM3ToPPM(unittest.TestCase):
 
     def test_converts_cm3_to_ppm(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/clip1.cm3"
+            importlib_resources.files(str(__package__)) / "fixtures/clip1.cm3"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/clip1.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/clip1.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.cm3toppm.start([str(infilename), self.outfile.name])
@@ -47,7 +47,7 @@ class TestCM3ToPPM(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/clip1.cm3"
+            importlib_resources.files(str(__package__)) / "fixtures/clip1.cm3"
         ) as infilename:
             infile_path = str(infilename)
             with self.assertRaises(subprocess.CalledProcessError) as context:
@@ -70,11 +70,11 @@ class TestCM3ToPPM(unittest.TestCase):
 
     @unix_only
     def test_converts_cm3_to_ppm_via_stdio(self) -> None:
-        with (importlib_resources.files(__package__) / "fixtures/clip1.cm3").open(
+        with (importlib_resources.files(str(__package__)) / "fixtures/clip1.cm3").open(
             "rb"
         ) as infile:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/clip1.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/clip1.ppm"
             ) as comparefilename:
                 read, write = os.pipe()
                 os.write(write, infile.read())
@@ -90,10 +90,10 @@ class TestCM3ToPPM(unittest.TestCase):
     @unix_only
     def test_converts_cm3_to_ppm_via_stdin(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/clip1.cm3"
+            importlib_resources.files(str(__package__)) / "fixtures/clip1.cm3"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/clip1.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/clip1.ppm"
             ) as comparefilename:
                 subprocess.check_call(
                     [sys.executable, "coco/cm3toppm.py", str(infilename)],

--- a/tests/coco_tests/test_hrstoppm.py
+++ b/tests/coco_tests/test_hrstoppm.py
@@ -43,10 +43,10 @@ class TestHRSToPPM(unittest.TestCase):
 
     def test_converts_hrs_to_ppm(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/monalisa.hrs"
+            importlib_resources.files(str(__package__)) / "fixtures/monalisa.hrs"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/monalisa.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/monalisa.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.hrstoppm.start([str(infilename), self.outfile.name])
@@ -54,10 +54,11 @@ class TestHRSToPPM(unittest.TestCase):
 
     def test_converts_hrs_to_ppm_with_height(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/monalisa.hrs"
+            importlib_resources.files(str(__package__)) / "fixtures/monalisa.hrs"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/monalisa_r97.ppm"
+                importlib_resources.files(str(__package__))
+                / "fixtures/monalisa_r97.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.hrstoppm.start(["-r", "97", str(infilename), self.outfile.name])
@@ -65,10 +66,11 @@ class TestHRSToPPM(unittest.TestCase):
 
     def test_converts_hrs_to_ppm_with_width(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/monalisa.hrs"
+            importlib_resources.files(str(__package__)) / "fixtures/monalisa.hrs"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/monalisa_w160.ppm"
+                importlib_resources.files(str(__package__))
+                / "fixtures/monalisa_w160.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.hrstoppm.start(["-w", "160", str(infilename), self.outfile.name])
@@ -76,10 +78,10 @@ class TestHRSToPPM(unittest.TestCase):
 
     def test_skipping_bytes(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/monalisa_s7.hrs"
+            importlib_resources.files(str(__package__)) / "fixtures/monalisa_s7.hrs"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/monalisa.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/monalisa.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.hrstoppm.start(["-s", "7", str(infilename), self.outfile.name])
@@ -88,7 +90,7 @@ class TestHRSToPPM(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/monalisa.hrs"
+            importlib_resources.files(str(__package__)) / "fixtures/monalisa.hrs"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(
@@ -110,11 +112,11 @@ class TestHRSToPPM(unittest.TestCase):
 
     @unix_only
     def test_converts_hrs_to_ppm_via_stdio(self) -> None:
-        with (importlib_resources.files(__package__) / "fixtures/monalisa.hrs").open(
-            "rb"
-        ) as infile:
+        with (
+            importlib_resources.files(str(__package__)) / "fixtures/monalisa.hrs"
+        ).open("rb") as infile:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/monalisa.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/monalisa.ppm"
             ) as comparefilename:
                 read, write = os.pipe()
                 os.write(write, infile.read())
@@ -130,10 +132,10 @@ class TestHRSToPPM(unittest.TestCase):
     @unix_only
     def test_converts_hrs_to_ppm_via_stdin(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/monalisa.hrs"
+            importlib_resources.files(str(__package__)) / "fixtures/monalisa.hrs"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/monalisa.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/monalisa.ppm"
             ) as comparefilename:
                 subprocess.check_call(
                     [sys.executable, "coco/hrstoppm.py", str(infilename)],

--- a/tests/coco_tests/test_maxtoppm.py
+++ b/tests/coco_tests/test_maxtoppm.py
@@ -42,10 +42,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name])
@@ -53,10 +53,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_br(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_rb.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_rb.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-rb"])
@@ -64,10 +64,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_rb(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_br.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_br.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-br"])
@@ -75,10 +75,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_br2(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_br2.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_br2.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-br2"])
@@ -86,10 +86,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_rb2(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_rb2.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_rb2.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-rb2"])
@@ -97,10 +97,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_br3(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_br3.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_br3.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-br3"])
@@ -108,10 +108,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_rb3(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_rb3.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_rb3.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-rb3"])
@@ -119,10 +119,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_s10(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_s10.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_s10.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-s10"])
@@ -130,10 +130,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_max_to_ppm_s11(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_s11.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_s11.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-s11"])
@@ -141,10 +141,11 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_specifying_width(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_rb_w128.ppm"
+                importlib_resources.files(str(__package__))
+                / "fixtures/eye4_rb_w128.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start(
@@ -154,10 +155,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_specifying_height(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4_r96.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4_r96.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-r", "96"])
@@ -165,10 +166,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_skipping_bytes(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4_s7.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4_s7.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-s", "7"])
@@ -176,10 +177,10 @@ class TestMaxToPPM(unittest.TestCase):
 
     def test_converts_newsroom_files(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/shamrock.art"
+            importlib_resources.files(str(__package__)) / "fixtures/shamrock.art"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/shamrock.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/shamrock.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-newsroom"])
@@ -188,7 +189,7 @@ class TestMaxToPPM(unittest.TestCase):
     @mock.patch("sys.stderr")
     def test_detects_bad_headers_1(self, mockStderr) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.bad1.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.bad1.max"
         ) as infilename:
             self.outfile.close()
             coco.maxtoppm.start([str(infilename), self.outfile.name])
@@ -198,10 +199,10 @@ class TestMaxToPPM(unittest.TestCase):
     @mock.patch("sys.stderr")
     def test_ignores_bad_headers_1(self, mockStderr) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.bad1.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.bad1.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-i"])
@@ -211,7 +212,7 @@ class TestMaxToPPM(unittest.TestCase):
     @mock.patch("sys.stderr")
     def test_detects_bad_headers_2(self, mockStderr) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.bad2.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.bad2.max"
         ) as infilename:
             self.outfile.close()
             coco.maxtoppm.start([str(infilename), self.outfile.name])
@@ -224,10 +225,10 @@ class TestMaxToPPM(unittest.TestCase):
     @mock.patch("sys.stderr")
     def test_ignores_bad_headers_2(self, mockStderr) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.bad2.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.bad2.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.maxtoppm.start([str(infilename), self.outfile.name, "-i"])
@@ -240,7 +241,7 @@ class TestMaxToPPM(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(
@@ -262,11 +263,11 @@ class TestMaxToPPM(unittest.TestCase):
 
     @unix_only
     def test_converts_max_to_ppm_via_stdio(self) -> None:
-        with (importlib_resources.files(__package__) / "fixtures/eye4.max").open(
+        with (importlib_resources.files(str(__package__)) / "fixtures/eye4.max").open(
             "rb"
         ) as infile:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4.ppm"
             ) as comparefilename:
                 read, write = os.pipe()
                 os.write(write, infile.read())
@@ -282,10 +283,10 @@ class TestMaxToPPM(unittest.TestCase):
     @unix_only
     def test_converts_max_to_ppm_via_stdin(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/eye4.max"
+            importlib_resources.files(str(__package__)) / "fixtures/eye4.max"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/eye4.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/eye4.ppm"
             ) as comparefilename:
                 subprocess.check_call(
                     [sys.executable, "coco/maxtoppm.py", infilename],

--- a/tests/coco_tests/test_mge_viewer2.py
+++ b/tests/coco_tests/test_mge_viewer2.py
@@ -23,7 +23,7 @@ class TestMGE_Viewer2(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/dragon1.mge"
+            importlib_resources.files(str(__package__)) / "fixtures/dragon1.mge"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(

--- a/tests/coco_tests/test_mgetoppm.py
+++ b/tests/coco_tests/test_mgetoppm.py
@@ -35,10 +35,10 @@ class TestMGEToPPM(unittest.TestCase):
 
     def test_converts_mge_to_ppm(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/dragon1.mge"
+            importlib_resources.files(str(__package__)) / "fixtures/dragon1.mge"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/dragon1.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/dragon1.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.mgetoppm.start([str(infilename), self.outfile.name])
@@ -47,7 +47,7 @@ class TestMGEToPPM(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/dragon1.mge"
+            importlib_resources.files(str(__package__)) / "fixtures/dragon1.mge"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(
@@ -69,11 +69,11 @@ class TestMGEToPPM(unittest.TestCase):
 
     @unix_only
     def test_converts_mge_to_ppm_via_stdio(self) -> None:
-        with (importlib_resources.files(__package__) / "fixtures/dragon1.mge").open(
-            "rb"
-        ) as infile:
+        with (
+            importlib_resources.files(str(__package__)) / "fixtures/dragon1.mge"
+        ).open("rb") as infile:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/dragon1.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/dragon1.ppm"
             ) as comparefilename:
                 read, write = os.pipe()
                 os.write(write, infile.read())
@@ -89,10 +89,10 @@ class TestMGEToPPM(unittest.TestCase):
     @unix_only
     def test_converts_mge_to_ppm_via_stdin(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/dragon1.mge"
+            importlib_resources.files(str(__package__)) / "fixtures/dragon1.mge"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/dragon1.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/dragon1.ppm"
             ) as comparefilename:
                 subprocess.check_call(
                     [sys.executable, "coco/mgetoppm.py", infilename],

--- a/tests/coco_tests/test_pixtopgm.py
+++ b/tests/coco_tests/test_pixtopgm.py
@@ -35,10 +35,10 @@ class TestPixToPGM(unittest.TestCase):
 
     def test_converts_pix_to_pgm(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/sue.pix"
+            importlib_resources.files(str(__package__)) / "fixtures/sue.pix"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/sue.pgm"
+                importlib_resources.files(str(__package__)) / "fixtures/sue.pgm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.pixtopgm.start([str(infilename), self.outfile.name])
@@ -47,7 +47,7 @@ class TestPixToPGM(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/sue.pix"
+            importlib_resources.files(str(__package__)) / "fixtures/sue.pix"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(
@@ -70,10 +70,10 @@ class TestPixToPGM(unittest.TestCase):
     @unix_only
     def test_converts_pix_to_pgm_via_stdout(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/sue.pix"
+            importlib_resources.files(str(__package__)) / "fixtures/sue.pix"
         ) as infile:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/sue.pgm"
+                importlib_resources.files(str(__package__)) / "fixtures/sue.pgm"
             ) as comparefilename:
                 subprocess.check_call(
                     [sys.executable, "coco/pixtopgm.py", infile],
@@ -108,7 +108,7 @@ class TestPixToPGM(unittest.TestCase):
     def test_unknown_argument(self) -> None:
         with self.assertRaises(subprocess.CalledProcessError) as context:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/sue.pix"
+                importlib_resources.files(str(__package__)) / "fixtures/sue.pix"
             ) as infile:
                 subprocess.check_output(
                     [sys.executable, "coco/pixtopgm.py", infile, "--oops"],

--- a/tests/coco_tests/test_png_utilities.py
+++ b/tests/coco_tests/test_png_utilities.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import filecmp
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -351,8 +353,8 @@ def test_png_to_mvicon(
 
 
 def _are_identical(
-    image1_path: str,
-    image2_path: str,
+    image1_path: str | Path,
+    image2_path: str | Path,
 ) -> bool:
     image1 = Image.open(image1_path)
     image2 = Image.open(image2_path)

--- a/tests/coco_tests/test_rattoppm.py
+++ b/tests/coco_tests/test_rattoppm.py
@@ -35,10 +35,10 @@ class TestRatToPPM(unittest.TestCase):
 
     def test_converts_rat_to_ppm(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/watrfall.rat"
+            importlib_resources.files(str(__package__)) / "fixtures/watrfall.rat"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/watrfall.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/watrfall.ppm"
             ) as comparefilename:
                 self.outfile.close()
                 coco.rattoppm.start([str(infilename), self.outfile.name])
@@ -47,7 +47,7 @@ class TestRatToPPM(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/watrfall.rat"
+            importlib_resources.files(str(__package__)) / "fixtures/watrfall.rat"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(
@@ -69,11 +69,11 @@ class TestRatToPPM(unittest.TestCase):
 
     @unix_only
     def test_converts_rat_to_ppm_via_stdio(self) -> None:
-        with (importlib_resources.files(__package__) / "fixtures/watrfall.rat").open(
-            "rb"
-        ) as infile:
+        with (
+            importlib_resources.files(str(__package__)) / "fixtures/watrfall.rat"
+        ).open("rb") as infile:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/watrfall.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/watrfall.ppm"
             ) as comparefilename:
                 read, write = os.pipe()
                 os.write(write, infile.read())
@@ -89,10 +89,10 @@ class TestRatToPPM(unittest.TestCase):
     @unix_only
     def test_converts_rat_to_ppm_via_stdin(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/watrfall.rat"
+            importlib_resources.files(str(__package__)) / "fixtures/watrfall.rat"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/watrfall.ppm"
+                importlib_resources.files(str(__package__)) / "fixtures/watrfall.ppm"
             ) as comparefilename:
                 subprocess.check_call(
                     [sys.executable, "coco/rattoppm.py", infilename],

--- a/tests/coco_tests/test_veftopng.py
+++ b/tests/coco_tests/test_veftopng.py
@@ -35,10 +35,10 @@ class TestVEFToPNG(unittest.TestCase):
 
     def test_converts_320x200x16_vef_to_png(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/trekies.vef"
+            importlib_resources.files(str(__package__)) / "fixtures/trekies.vef"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/trekies.png"
+                importlib_resources.files(str(__package__)) / "fixtures/trekies.png"
             ) as comparefilename:
                 self.outfile.close()
                 coco.veftopng.start([str(infilename), self.outfile.name])
@@ -47,10 +47,10 @@ class TestVEFToPNG(unittest.TestCase):
 
     def test_converts_640x200x4_vef_to_png(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/owlcasl.vef"
+            importlib_resources.files(str(__package__)) / "fixtures/owlcasl.vef"
         ) as infilename:
             with importlib_resources.as_file(
-                importlib_resources.files(__package__) / "fixtures/owlcasl.png"
+                importlib_resources.files(str(__package__)) / "fixtures/owlcasl.png"
             ) as comparefilename:
                 self.outfile.close()
                 coco.veftopng.start([str(infilename), self.outfile.name])
@@ -61,7 +61,7 @@ class TestVEFToPNG(unittest.TestCase):
     @unix_only
     def test_too_many_arguments(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/trekies.vef"
+            importlib_resources.files(str(__package__)) / "fixtures/trekies.vef"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(
@@ -106,7 +106,7 @@ class TestVEFToPNG(unittest.TestCase):
     @unix_only
     def test_unknown_argument(self) -> None:
         with importlib_resources.as_file(
-            importlib_resources.files(__package__) / "fixtures/trekies.vef"
+            importlib_resources.files(str(__package__)) / "fixtures/trekies.vef"
         ) as infilename:
             with self.assertRaises(subprocess.CalledProcessError) as context:
                 subprocess.check_output(

--- a/tests/coco_tests/util.py
+++ b/tests/coco_tests/util.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import platform
+from pathlib import Path
 
 import imagehash
 import pytest
@@ -11,7 +14,10 @@ unix_only = pytest.mark.skipif(
 
 # From google ai
 def compare_images_imagehash(
-    image_path1: str, image_path2: str, hash_size: int = 8, similarity_cutoff: int = 5
+    image_path1: str | Path,
+    image_path2: str | Path,
+    hash_size: int = 8,
+    similarity_cutoff: int = 5,
 ) -> bool:
     img1 = Image.open(image_path1)
     img2 = Image.open(image_path2)


### PR DESCRIPTION
## Summary
- Add `check-types` Makefile target that runs the `ty` type checker, integrated into `check-all`
- Fix all 187 type errors across the codebase (widened annotations, fixed visitor pattern hierarchy, added `from __future__ import annotations`, etc.)
- Replace `make help` with a self-documenting `##` comment system that auto-generates a formatted help listing
- Clean up `test_b09.py` imports to use direct module references, removing `# noqa` comments

## Test plan
- [x] `make check-all` passes (ruff lint + ty type check, 0 errors, 0 warnings)
- [x] `make run-tests` passes (367 tests, all green)
- [x] `make help` displays formatted target list with descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)